### PR TITLE
Add Portuguese localization coverage for deposit error responses

### DIFF
--- a/configuration/src/main/resources/messages.properties
+++ b/configuration/src/main/resources/messages.properties
@@ -13,3 +13,5 @@ validation.transaction.history.start.date.invalid=The initial date is invalid!
 validation.transaction.history.end.date.invalid=The final date is invalid!
 validation.wallet.id.notfound=The wallet with the identifier ''{0}'' was not found!
 validation.wallet.userId.blank=The user identifier is required!
+validation.transaction.deposit.amount.null=The deposit amount is required!
+validation.transaction.deposit.amount.invalid=The deposit amount is invalid!

--- a/configuration/src/main/resources/messages_pt_BR.properties
+++ b/configuration/src/main/resources/messages_pt_BR.properties
@@ -13,3 +13,5 @@ validation.transaction.history.start.date.invalid=A data inicial é inválida!
 validation.transaction.history.end.date.invalid=A data final é inválida!
 validation.wallet.id.notfound=A carteira com o identificador ''{0}'' não foi encontrada!
 validation.wallet.userId.blank=O identificador do usuário é obrigatório!
+validation.transaction.deposit.amount.null=O valor do depósito é obrigatório!
+validation.transaction.deposit.amount.invalid=O valor do depósito é inválido!

--- a/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/transaction/DepositControllerTest.java
+++ b/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/transaction/DepositControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -76,8 +77,8 @@ class DepositControllerTest {
         // Act
         // Assert
         mockMvc.perform(post("/v1/wallets/1/deposits")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(buildDepositRequest()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(buildDepositRequest("100.01")))
                .andDo(print())
                .andExpect(status().isCreated())
                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -88,8 +89,33 @@ class DepositControllerTest {
                .andExpect(jsonPath("$.updatedAt", is("2025-02-14T22:04:59.456")));
     }
 
-    private String buildDepositRequest() throws JsonProcessingException {
-        final DepositRequest request = new DepositRequest("100.01");
+    @DisplayName("Fail to deposit an amount with invalid value in Portuguese")
+    @Test
+    void failToDepositAnAmountWithInvalidValueInPortuguese() throws Exception {
+
+        // Arrange
+        when(webRequest.getEmail()).thenReturn("joe.doe.one@xyz.com");
+        when(webRequest.getFullName()).thenReturn("Joe Doe");
+        when(webRequest.getPath()).thenReturn("/v1/wallets/1/deposits");
+
+        // Act
+        // Assert
+        mockMvc.perform(post("/v1/wallets/1/deposits")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.ACCEPT_LANGUAGE, "pt_BR")
+                        .content(buildDepositRequest("0.00")))
+               .andDo(print())
+               .andExpect(status().isBadRequest())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$.timestamp").exists())
+               .andExpect(jsonPath("$.status", is(400)))
+               .andExpect(jsonPath("$.error", is("Bad Request")))
+               .andExpect(jsonPath("$.message", is("O valor do depósito é inválido!")))
+               .andExpect(jsonPath("$.path", is("/v1/wallets/1/deposits")));
+    }
+
+    private String buildDepositRequest(final String amount) throws JsonProcessingException {
+        final DepositRequest request = new DepositRequest(amount);
         return new ObjectMapper().writeValueAsString(request);
     }
 }


### PR DESCRIPTION
## Summary
- add missing message bundle entries for deposit amount validation keys
- extend the deposit controller web test to assert the Portuguese translation when Accept-Language is set

## Testing
- mvn test *(fails: Non-resolvable parent POM from Maven Central — 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f83a3458cc83309ce4cd02a8baaf0f