### PR TITLE
Add test for blank userId wallet creation

### DIFF
--- a/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/wallet/CreateWalletControllerTest.java
+++ b/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/wallet/CreateWalletControllerTest.java
@@ -89,6 +89,21 @@ class CreateWalletControllerTest {
         verifyNoMoreInteractions(createWalletUseCase);
     }
 
+    @DisplayName("Fail to create a wallet when userId is blank")
+    @Test
+    void failToCreateWalletWhenUserIdIsBlank() throws Exception {
+
+        mockMvc.perform(post("/v1/wallets").content("{\"userId\":\"\"}")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", is("validation.wallet.userId.blank")))
+                .andExpect(jsonPath("$.path", is("/v1/wallets")));
+
+        verifyNoInteractions(createWalletUseCase);
+    }
+
     private String buildRequestBody() throws JsonProcessingException {
         final CreateWalletRequest request = new CreateWalletRequest("red");
         return new ObjectMapper().writeValueAsString(request);


### PR DESCRIPTION
## Summary
- add a MockMvc test that posts an empty userId payload to the wallet creation endpoint
- assert the validation error response and ensure the createWalletUseCase is not invoked

## Testing
- mvn -pl entrypoints/rest test *(fails: unable to download parent POM due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f83a19f2388330841a3fd39f2727b7