### PR TITLE
Add wallet balance not found error handling test

### DIFF
--- a/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/wallet/RetrieveBalanceControllerTest.java
+++ b/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/wallet/RetrieveBalanceControllerTest.java
@@ -2,6 +2,7 @@ package io.github.jtsato.walletservice.entrypoint.rest.domains.wallet;
 
 import io.github.jtsato.walletservice.core.domains.wallet.model.Wallet;
 import io.github.jtsato.walletservice.core.domains.wallet.usecase.balance.RetrieveBalanceUseCase;
+import io.github.jtsato.walletservice.core.exception.NotFoundException;
 import io.github.jtsato.walletservice.entrypoint.rest.common.WebRequest;
 import io.github.jtsato.walletservice.entrypoint.rest.domains.wallet.balance.RetrieveBalanceController;
 import org.junit.jupiter.api.DisplayName;
@@ -14,14 +15,18 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.MessageSource;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Locale;
 
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -41,6 +46,9 @@ class RetrieveBalanceControllerTest {
     @Autowired
     private WebRequest webRequest;
 
+    @Autowired
+    private MessageSource messageSource;
+
     @TestConfiguration
     static class TestConfig {
 
@@ -54,6 +62,12 @@ class RetrieveBalanceControllerTest {
         @Primary
         public WebRequest mockWebRequest() {
             return Mockito.mock(WebRequest.class);
+        }
+
+        @Bean
+        @Primary
+        public MessageSource mockMessageSource() {
+            return Mockito.mock(MessageSource.class);
         }
     }
 
@@ -76,5 +90,27 @@ class RetrieveBalanceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.balance", is(1001.01)));
+    }
+
+    @DisplayName("Fail to get balance by wallet id when wallet is not found")
+    @Test
+    void failToRetrieveBalanceWhenWalletIdIsNotFound() throws Exception {
+
+        // Arrange
+        when(webRequest.getPath()).thenReturn("/v1/wallets/1/balances");
+        when(messageSource.getMessage(eq("validation.wallet.id.notfound"), eq(new Object[]{"1"}), any(Locale.class)))
+                .thenReturn("A carteira com o identificador '1' não foi encontrada!");
+        when(retrieveBalanceUseCase.execute(1L))
+                .thenThrow(new NotFoundException("validation.wallet.id.notfound", "1"));
+
+        // Act
+        // Assert
+        mockMvc.perform(get("/v1/wallets/1/balances")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.message", is("A carteira com o identificador '1' não foi encontrada!")))
+                .andExpect(jsonPath("$.status", is(404)));
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated test that mocks the balance retrieval use case to throw NotFoundException
- assert the controller returns a 404 response with the translated message when the wallet is missing

## Testing
- mvn -pl entrypoints/rest test *(fails: cannot download org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f83a1ea3a88330aba8c46c4c3e4629