### PR TITLE
Add not found deposit controller test

### DIFF
--- a/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/transaction/DepositControllerTest.java
+++ b/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/transaction/DepositControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.jtsato.walletservice.core.domains.transactions.usecase.deposit.DepositCommand;
 import io.github.jtsato.walletservice.core.domains.transactions.usecase.deposit.DepositUseCase;
+import io.github.jtsato.walletservice.core.exception.NotFoundException;
 import io.github.jtsato.walletservice.core.domains.wallet.model.Wallet;
 import io.github.jtsato.walletservice.entrypoint.rest.common.WebRequest;
 import io.github.jtsato.walletservice.entrypoint.rest.domains.transaction.deposit.DepositController;
@@ -86,6 +87,29 @@ class DepositControllerTest {
                .andExpect(jsonPath("$.balance", is(200.01)))
                .andExpect(jsonPath("$.createdAt", is("2025-02-14T22:04:59.123")))
                .andExpect(jsonPath("$.updatedAt", is("2025-02-14T22:04:59.456")));
+    }
+
+    @DisplayName("Fail to deposit when wallet was not found")
+    @Test
+    void failToDepositWhenWalletWasNotFound() throws Exception {
+
+        // Arrange
+        when(webRequest.getEmail()).thenReturn("joe.doe.one@xyz.com");
+        when(webRequest.getPath()).thenReturn("/v1/wallets/1/deposits");
+
+        final DepositCommand command = new DepositCommand(1L, "100.01");
+        when(depositUseCase.execute(command)).thenThrow(new NotFoundException("validation.wallet.id.notfound", "1"));
+
+        // Act
+        // Assert
+        mockMvc.perform(post("/v1/wallets/1/deposits")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(buildDepositRequest()))
+               .andDo(print())
+               .andExpect(status().isNotFound())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$.message", is("The wallet with the identifier '1' was not found!")))
+               .andExpect(jsonPath("$.path", is("/v1/wallets/1/deposits")));
     }
 
     private String buildDepositRequest() throws JsonProcessingException {


### PR DESCRIPTION
## Summary
- add a DepositController MVC test covering the not-found use case when the use case throws NotFoundException
- verify the HTTP 404 status, translated error message, and request path returned by the exception handler

## Testing
- `mvn -pl entrypoints/rest test -Dtest=DepositControllerTest` *(fails: unable to download parent POM because Maven Central returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f83a2531c08330ba2153f27993c393