### PR TITLE
Add controller test for missing wallet request body

### DIFF
--- a/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/wallet/CreateWalletControllerTest.java
+++ b/entrypoints/rest/src/test/java/io/github/jtsato/walletservice/entrypoint/rest/domains/wallet/CreateWalletControllerTest.java
@@ -89,6 +89,18 @@ class CreateWalletControllerTest {
         verifyNoMoreInteractions(createWalletUseCase);
     }
 
+    @DisplayName("Fail to create a wallet with missing request body")
+    @Test
+    void failToCreateAWalletWithMissingRequestBody() throws Exception {
+
+        mockMvc.perform(post("/v1/wallets").contentType(MediaType.APPLICATION_JSON_VALUE).accept(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", is("exception.request.body.is.invalid.or.missing")));
+
+        verifyNoInteractions(createWalletUseCase);
+    }
+
     private String buildRequestBody() throws JsonProcessingException {
         final CreateWalletRequest request = new CreateWalletRequest("red");
         return new ObjectMapper().writeValueAsString(request);


### PR DESCRIPTION
## Summary
- add a MockMvc test that posts to `/v1/wallets` without a request body
- assert the controller returns a bad request with the expected error message
- verify the use case is not invoked when the body is missing

## Testing
- `mvn -pl entrypoints/rest test -Dtest=CreateWalletControllerTest` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68f83a1c73ac833085eacb9ee0de3e69